### PR TITLE
Dev/btm 795 key limit

### DIFF
--- a/cloudformation/event-bucketing.yaml
+++ b/cloudformation/event-bucketing.yaml
@@ -18,7 +18,8 @@ Resources:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.
           STORAGE_BUCKET: !Sub ${AWS::StackName}-storage
-          BUCKETING_DAYS_TO_PROCESS: 7
+          BUCKETING_DAYS_TO_PROCESS: 1
+          BUCKETING_FILE_COUNT: 3000
       EventInvokeConfig:
         MaximumEventAgeInSeconds: 60
       Handler: eventBucketing.handler

--- a/cloudformation/event-bucketing.yaml
+++ b/cloudformation/event-bucketing.yaml
@@ -57,8 +57,8 @@ Resources:
                 - s3:ListBucket
                 - s3:ListBucketMultipartUploads
                 - s3:ListMultipartUploadParts
-                - s3:PutObject*
-                - s3:DeleteObject*
+                - s3:PutObject
+                - s3:DeleteObject
               Resource:
                 - !Sub arn:aws:s3:::${AWS::StackName}-storage
                 - !Sub arn:aws:s3:::${AWS::StackName}-storage/*

--- a/src/handlers/event-bucketing/business-logic.test.ts
+++ b/src/handlers/event-bucketing/business-logic.test.ts
@@ -33,6 +33,7 @@ describe("Event bucketing businessLogic", () => {
       env: {
         STORAGE_BUCKET: "storage_bucket",
         BUCKETING_DAYS_TO_PROCESS: "7",
+        BUCKETING_FILE_COUNT: "3000",
       },
       logger: {
         info: givenInfoLogger,
@@ -95,7 +96,7 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
       folder1.key,
-      9999999
+      parseInt(givenCtx.env.BUCKETING_FILE_COUNT)
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(2);
@@ -137,7 +138,9 @@ describe("Event bucketing businessLogic", () => {
 
     expect(mockedBackupEventFile).toBeCalledTimes(14);
 
-    expect(mockedStoreBucketingFile).toBeCalledTimes(7);
+    expect(mockedStoreBucketingFile).toBeCalledTimes(
+      parseInt(givenCtx.env.BUCKETING_DAYS_TO_PROCESS)
+    );
   });
 
   test("Processing 1 folder with 501 files, expecting 2 consolidation files", async () => {
@@ -152,7 +155,7 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
       folder1.key,
-      9999999
+      parseInt(givenCtx.env.BUCKETING_FILE_COUNT)
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(501);
@@ -172,12 +175,12 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
       folder1.key,
-      9999999
+      parseInt(givenCtx.env.BUCKETING_FILE_COUNT)
     );
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
       folder2.key,
-      9999999
+      parseInt(givenCtx.env.BUCKETING_FILE_COUNT)
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(2);
@@ -217,12 +220,12 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
       folder1.key,
-      9999999
+      parseInt(givenCtx.env.BUCKETING_FILE_COUNT)
     );
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
       folder2.key,
-      9999999
+      parseInt(givenCtx.env.BUCKETING_FILE_COUNT)
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(3);

--- a/src/handlers/event-bucketing/business-logic.test.ts
+++ b/src/handlers/event-bucketing/business-logic.test.ts
@@ -94,7 +94,8 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledTimes(1);
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
-      folder1.key
+      folder1.key,
+      9999999
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(2);
@@ -150,7 +151,8 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledTimes(1);
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
-      folder1.key
+      folder1.key,
+      9999999
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(501);
@@ -169,11 +171,13 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledTimes(2);
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
-      folder1.key
+      folder1.key,
+      9999999
     );
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
-      folder2.key
+      folder2.key,
+      9999999
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(2);
@@ -212,11 +216,13 @@ describe("Event bucketing businessLogic", () => {
     expect(mockedGetKeys).toBeCalledTimes(2);
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
-      folder1.key
+      folder1.key,
+      9999999
     );
     expect(mockedGetKeys).toBeCalledWith(
       givenCtx.env.STORAGE_BUCKET,
-      folder2.key
+      folder2.key,
+      9999999
     );
 
     expect(mockedGetFileContent).toBeCalledTimes(3);

--- a/src/handlers/event-bucketing/business-logic.ts
+++ b/src/handlers/event-bucketing/business-logic.ts
@@ -19,10 +19,17 @@ export const businessLogic: BusinessLogic<
   );
   for (const folderKey of foldersToProcess) {
     logger.info(`getting files for ${folderKey}`);
-    const keys = await getKeys(env.STORAGE_BUCKET, folderKey);
+    const keys: string[] = await getKeys(
+      env.STORAGE_BUCKET,
+      folderKey,
+      9999999
+    );
+    logger.info(`${keys.length} keys ready to process in ${folderKey}`);
     // skip processed files (automated method)
+    // TODO: check for additional files even if bucketed files are present
+    // keys = filterProcessedFileKeys(keys);
     if (!keys.length || checkForProcessedFileKeys(keys)) {
-      logger.info(`${folderKey} does not require processing`);
+      logger.info(`${folderKey} does not require further processing`);
       continue;
     }
     const contents: string[] = [];
@@ -102,6 +109,15 @@ const checkForProcessedFileKeys = (fileKeys: string[]): boolean => {
     );
   });
 };
+
+// const filterProcessedFileKeys = (fileKeys: string[]): string[] => {
+//   return fileKeys.filter((fileKey) => {
+//     const fileKeyParts = fileKey.split("/");
+//     return fileKeyParts[fileKeyParts.length - 1].startsWith(
+//       "bucketing-extract-"
+//     );
+//   });
+// };
 
 const checkForProcessedFileContent = (fileContent: string): boolean => {
   return (fileContent.match(/\n/g) ?? []).length > 0;

--- a/src/handlers/event-bucketing/business-logic.ts
+++ b/src/handlers/event-bucketing/business-logic.ts
@@ -25,9 +25,8 @@ export const businessLogic: BusinessLogic<
       parseInt(env.BUCKETING_FILE_COUNT)
     );
     logger.info(`${keys.length} keys ready to process in ${folderKey}`);
-    // skip processed files (automated method)
-    // TODO: check for additional files even if bucketed files are present
     keys = filterProcessedFileKeys(keys);
+    // skip processed files (automated method)
     if (!keys.length) {
       logger.info(`${folderKey} does not require further processing`);
       continue;

--- a/src/handlers/event-bucketing/handler.test.ts
+++ b/src/handlers/event-bucketing/handler.test.ts
@@ -19,6 +19,7 @@ describe("Store Standardised Invoices handler tests", () => {
     mockedEnv = {
       BUCKETING_DAYS_TO_PROCESS: "given days to process",
       STORAGE_BUCKET: "given storage bucket",
+      BUCKETING_FILE_COUNT: "given file count",
     };
 
     mockedGetFromEnv.mockImplementation((key) => mockedEnv[key]);

--- a/src/handlers/event-bucketing/handler.ts
+++ b/src/handlers/event-bucketing/handler.ts
@@ -5,7 +5,11 @@ import { Env } from "./types";
 
 export const handler = buildHandler({
   businessLogic,
-  envVars: [Env.STORAGE_BUCKET, Env.BUCKETING_DAYS_TO_PROCESS],
+  envVars: [
+    Env.STORAGE_BUCKET,
+    Env.BUCKETING_DAYS_TO_PROCESS,
+    Env.BUCKETING_FILE_COUNT,
+  ],
   incomingMessageBodyTypeGuard: isValidIncomingMessageBody,
   outputs: [],
   withBatchItemFailures: false,

--- a/src/handlers/event-bucketing/s3connect.test.ts
+++ b/src/handlers/event-bucketing/s3connect.test.ts
@@ -28,8 +28,8 @@ describe("store", () => {
   });
 
   it("gets the file keys from S3 that belong to the provided bucket and folder", async () => {
-    await getKeys(bucket, folderKey);
-    expect(listS3Keys).toHaveBeenCalledWith(bucket, folderKey);
+    await getKeys(bucket, folderKey, 7000);
+    expect(listS3Keys).toHaveBeenCalledWith(bucket, folderKey, 7000);
   });
 
   it("returns the file content for the givenfile key and S3 bucket", async () => {

--- a/src/handlers/event-bucketing/s3connect.ts
+++ b/src/handlers/event-bucketing/s3connect.ts
@@ -20,9 +20,10 @@ export const storeBucketingFile = async (
 
 export const getKeys = async (
   bucket: string,
-  key: string
+  key: string,
+  maxKeys?: number
 ): Promise<string[]> => {
-  return await listS3Keys(bucket, key);
+  return await listS3Keys(bucket, key, maxKeys);
 };
 
 export const getFileContent = async (
@@ -36,14 +37,24 @@ export const backUpEventFile = async (
   bucket: string,
   sourceKey: string
 ): Promise<void> => {
-  return await moveS3(bucket, sourceKey, bucket, `btm_event_data_copy/${sourceKey}`);
+  return await moveS3(
+    bucket,
+    sourceKey,
+    bucket,
+    `btm_event_data_copy/${sourceKey}`
+  );
 };
 
 export const moveBucketedFile = async (
   bucket: string,
   sourceKey: string
 ): Promise<void> => {
-  return await moveS3(bucket, `btm_event_data_copy/${sourceKey}`, bucket, sourceKey);
+  return await moveS3(
+    bucket,
+    `btm_event_data_copy/${sourceKey}`,
+    bucket,
+    sourceKey
+  );
 };
 
 export const deleteFile = async (

--- a/src/handlers/event-bucketing/types.ts
+++ b/src/handlers/event-bucketing/types.ts
@@ -3,6 +3,7 @@ import { ConfigElements } from "../../shared/constants";
 export enum Env {
   STORAGE_BUCKET = "STORAGE_BUCKET",
   BUCKETING_DAYS_TO_PROCESS = "BUCKETING_DAYS_TO_PROCESS",
+  BUCKETING_FILE_COUNT = "BUCKETING_FILE_COUNT",
 }
 
 export interface MessageBody {

--- a/src/shared/utils/env.ts
+++ b/src/shared/utils/env.ts
@@ -18,7 +18,8 @@ export type EnvVarName =
   | "STORAGE_BUCKET"
   | "TEXTRACT_ROLE"
   | "TEXTRACT_SNS_TOPIC"
-  | "BUCKETING_DAYS_TO_PROCESS";
+  | "BUCKETING_DAYS_TO_PROCESS"
+  | "BUCKETING_FILE_COUNT";
 
 export const getFromEnv = (varName: EnvVarName): string | undefined =>
   process.env[varName];

--- a/src/shared/utils/s3/base.ts
+++ b/src/shared/utils/s3/base.ts
@@ -120,11 +120,13 @@ const isEncryptedS3ObjectMetadata = (
 
 export const listS3Keys = async (
   bucket: string,
-  prefix: string
+  prefix: string,
+  maxKeys?: number
 ): Promise<string[]> => {
   const listCommand = new ListObjectsCommand({
     Bucket: bucket,
     Prefix: prefix,
+    MaxKeys: maxKeys,
   });
 
   const result = await send(listCommand);


### PR DESCRIPTION
default limit when getting object keys is 1000, changed to 99999 so bucketing will work fully