### PR TITLE
BTM-685 Filter non DVLA if Driving license is set

### DIFF
--- a/src/handlers/filter/business-logic.test.ts
+++ b/src/handlers/filter/business-logic.test.ts
@@ -24,6 +24,14 @@ describe("Filter businessLogic", () => {
             event_name: "SPIRIT_CONSUMPTION_EXECUTION_TASK_START",
             contract_id: "1",
           },
+          {
+            vendor_name: "Ven1_e1's",
+            vendor_id: "ven_1",
+            service_name: "Spirit Level Bubbles",
+            service_regex: "SDH[0-9]{0,5} bubble",
+            event_name: "DL_VENDOR_1_EVENT_1",
+            contract_id: "1",
+          },
         ],
       },
     } as any;
@@ -46,6 +54,46 @@ describe("Filter businessLogic", () => {
 
     const result = await businessLogic(ignoredRecord, givenCtx);
 
+    expect(result).toEqual([]);
+  });
+
+  it("returns message with valid event name and DVLA", async () => {
+    const validRecord = {
+      event_id: "VENDOR_1_EVENT_1_WITH_DVLA",
+      event_name: "DL_VENDOR_1_EVENT_1",
+      timestamp: 1667401206,
+      timestamp_formatted: "2022-11-07T16:00:11.000Z",
+      component_id: "IPV",
+      restricted: {
+        drivingPermit: [
+          {
+            issuedBy: "DVLA",
+          },
+        ],
+      },
+    };
+
+    const result = await businessLogic(validRecord, givenCtx);
+    expect(result).toEqual([validRecord]);
+  });
+
+  it("returns message with valid event name and DVLA", async () => {
+    const validRecord = {
+      event_id: "VENDOR_1_EVENT_1_WITH_DVA",
+      event_name: "DL_VENDOR_1_EVENT_1",
+      timestamp: 1667401206,
+      timestamp_formatted: "2022-11-07T16:00:11.000Z",
+      component_id: "IPV",
+      restricted: {
+        drivingPermit: [
+          {
+            issuedBy: "DVA",
+          },
+        ],
+      },
+    };
+
+    const result = await businessLogic(validRecord, givenCtx);
     expect(result).toEqual([]);
   });
 });

--- a/src/handlers/filter/business-logic.ts
+++ b/src/handlers/filter/business-logic.ts
@@ -11,5 +11,14 @@ export const businessLogic: BusinessLogic<
     services.map(({ event_name }) => event_name)
   );
 
-  return validEventNames.has(messageBody.event_name) ? [messageBody] : [];
+  let valid: boolean;
+
+  valid = validEventNames.has(messageBody.event_name);
+
+  // If the driving permit is set, only allow DVLA events to be counted
+  if (valid && messageBody.restricted !== undefined) {
+    valid = messageBody.restricted.drivingPermit[0].issuedBy === "DVLA";
+  }
+
+  return valid ? [messageBody] : [];
 };

--- a/src/handlers/filter/types.ts
+++ b/src/handlers/filter/types.ts
@@ -2,7 +2,16 @@ import { ConfigElements } from "../../shared/constants";
 
 export interface MessageBody {
   event_name: string;
+  restricted?: Restricted;
 }
+
+export type Restricted = {
+  drivingPermit: DrivingPermit[];
+};
+
+export type DrivingPermit = {
+  issuedBy: string;
+};
 
 export enum Env {
   OUTPUT_QUEUE_URL = "OUTPUT_QUEUE_URL",


### PR DESCRIPTION
ID Events relating to Driving Licenses will be supported. For now, we want to only consider these events if the License was issued by DVLA.