### PR TITLE
BTM-916 Adding Additional memory to lambda Function 

### DIFF
--- a/cloudformation/csv-extraction.yaml
+++ b/cloudformation/csv-extraction.yaml
@@ -29,6 +29,7 @@ Resources:
               - ReportBatchItemFailures
             Queue: !GetAtt CsvExtractQueue.Arn
       Handler: csvExtract.handler
+      MemorySize: 256
       KmsKeyArn: !GetAtt KmsKey.Arn
       Policies:
         - AWSLambdaVPCAccessExecutionRole

--- a/cloudformation/custom-athena-view-resource.yaml
+++ b/cloudformation/custom-athena-view-resource.yaml
@@ -20,6 +20,7 @@ Resources:
         TargetArn: !GetAtt CustomAthenaViewResourceFunctionDeadLetterQueue.Arn
         Type: SQS
       Handler: customAthenaViewResource.handler
+      MemorySize: 256
       KmsKeyArn: !GetAtt KmsKey.Arn
       Policies:
         - AWSLambdaVPCAccessExecutionRole

--- a/cloudformation/dashboard-data-extraction.yaml
+++ b/cloudformation/dashboard-data-extraction.yaml
@@ -24,6 +24,7 @@ Resources:
       EventInvokeConfig:
         MaximumEventAgeInSeconds: 60
       Handler: dashboardExtract.handler
+      MemorySize: 256
       KmsKeyArn: !GetAtt KmsKey.Arn
       Timeout: 900
       Policies:

--- a/cloudformation/event-bucketing.yaml
+++ b/cloudformation/event-bucketing.yaml
@@ -22,6 +22,7 @@ Resources:
       EventInvokeConfig:
         MaximumEventAgeInSeconds: 60
       Handler: eventBucketing.handler
+      MemorySize: 4096
       KmsKeyArn: !GetAtt KmsKey.Arn
       Timeout: 900
       Policies:

--- a/cloudformation/filtering.yaml
+++ b/cloudformation/filtering.yaml
@@ -59,6 +59,7 @@ Resources:
           CONFIG_BUCKET: !GetAtt ConfigStackParameter.Value
           POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-filter-function
       Handler: filter.handler
+      MemorySize: 256
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - Statement:

--- a/cloudformation/frontend.yaml
+++ b/cloudformation/frontend.yaml
@@ -184,6 +184,7 @@ Resources:
             Path: /*
             Method: 'GET'
       Handler: frontend.handler
+      MemorySize: 256
       KmsKeyArn: !GetAtt KmsKey.Arn
       Policies:
         - Statement:

--- a/cloudformation/pdf-extraction.yaml
+++ b/cloudformation/pdf-extraction.yaml
@@ -27,6 +27,7 @@ Resources:
               - ReportBatchItemFailures
             Queue: !GetAtt PdfExtractQueue.Arn
       Handler: pdfExtract.handler
+      MemorySize: 256
       KmsKeyArn: !GetAtt KmsKey.Arn
       Policies:
         - AWSLambdaVPCAccessExecutionRole

--- a/cloudformation/pdf-standardisation.yaml
+++ b/cloudformation/pdf-standardisation.yaml
@@ -83,6 +83,7 @@ Resources:
               - ReportBatchItemFailures
             Queue: !GetAtt PdfStandardisationQueue.Arn
       Handler: pdfStandardisation.handler
+      MemorySize: 256
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - Statement:

--- a/cloudformation/standardised-invoice-storage.yaml
+++ b/cloudformation/standardised-invoice-storage.yaml
@@ -102,6 +102,7 @@ Resources:
               - ReportBatchItemFailures
             Queue: !GetAtt StandardisedInvoiceStorageQueue.Arn
       Handler: storeStandardisedInvoices.handler
+      MemorySize: 256
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - Statement:

--- a/cloudformation/synthetic-event-generation.yaml
+++ b/cloudformation/synthetic-event-generation.yaml
@@ -22,6 +22,7 @@ Resources:
           STORAGE_BUCKET: !Ref StorageBucket
           POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-synthetic-event-generation-function
       Handler: syntheticEvents.handler
+      MemorySize: 256
       KmsKeyArn: !GetAtt KmsKey.Arn
       Timeout: 180
       Policies:

--- a/cloudformation/transaction-csv-to-json-event.yaml
+++ b/cloudformation/transaction-csv-to-json-event.yaml
@@ -60,6 +60,7 @@ Resources:
           CONFIG_BUCKET: !GetAtt ConfigStackParameter.Value
           POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-transaction-csv-to-json-event-function
       Handler: transactionCsvToJsonEvent.handler
+      MemorySize: 256
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - Statement:

--- a/cloudformation/transaction-storage.yaml
+++ b/cloudformation/transaction-storage.yaml
@@ -64,6 +64,7 @@ Resources:
           LOCAL_ENDPOINT: !If [IsLocal, 'http://s3.localhost.localstack.cloud:4566', !Ref AWS::NoValue]
           POWERTOOLS_SERVICE_NAME: !Sub ${AWS::StackName}-storage-function
       Handler: storeTransactions.handler
+      MemorySize: 256
       Policies:
         - AWSLambdaVPCAccessExecutionRole
         - Statement:


### PR DESCRIPTION
Adding Additional memory to lambda Function  because some function are failing on default memory 128 mb. so doubling it to 256mb  and adding eventBucketing function large memory 4096mb   since this function is heavy s3 intensive processing 