### PR TITLE
BTM-918 Fix for Filter non DVLA if Driving license is set

### DIFF
--- a/src/handlers/filter/business-logic.test.ts
+++ b/src/handlers/filter/business-logic.test.ts
@@ -65,11 +65,9 @@ describe("Filter businessLogic", () => {
       timestamp_formatted: "2022-11-07T16:00:11.000Z",
       component_id: "IPV",
       restricted: {
-        drivingPermit: [
-          {
-            issuedBy: "DVLA",
-          },
-        ],
+        drivingPermit: {
+          issuedBy: ["DVLA"],
+        },
       },
     };
 
@@ -77,7 +75,7 @@ describe("Filter businessLogic", () => {
     expect(result).toEqual([validRecord]);
   });
 
-  it("returns message with valid event name and DVLA", async () => {
+  it("returns message with valid event name and DVA", async () => {
     const validRecord = {
       event_id: "VENDOR_1_EVENT_1_WITH_DVA",
       event_name: "DL_VENDOR_1_EVENT_1",
@@ -85,11 +83,9 @@ describe("Filter businessLogic", () => {
       timestamp_formatted: "2022-11-07T16:00:11.000Z",
       component_id: "IPV",
       restricted: {
-        drivingPermit: [
-          {
-            issuedBy: "DVA",
-          },
-        ],
+        drivingPermit: {
+          issuedBy: ["DVA"],
+        },
       },
     };
 

--- a/src/handlers/filter/business-logic.ts
+++ b/src/handlers/filter/business-logic.ts
@@ -16,8 +16,12 @@ export const businessLogic: BusinessLogic<
   valid = validEventNames.has(messageBody.event_name);
 
   // If the driving permit is set, only allow DVLA events to be counted
-  if (valid && messageBody.restricted !== undefined) {
-    valid = messageBody.restricted.drivingPermit[0].issuedBy === "DVLA";
+  if (
+    valid &&
+    messageBody.restricted !== undefined &&
+    messageBody.restricted.drivingPermit !== undefined
+  ) {
+    valid = messageBody.restricted.drivingPermit.issuedBy[0] === "DVLA";
   }
 
   return valid ? [messageBody] : [];

--- a/src/handlers/filter/types.ts
+++ b/src/handlers/filter/types.ts
@@ -6,11 +6,11 @@ export interface MessageBody {
 }
 
 export type Restricted = {
-  drivingPermit: DrivingPermit[];
+  drivingPermit: DrivingPermit;
 };
 
 export type DrivingPermit = {
-  issuedBy: string;
+  issuedBy: string[];
 };
 
 export enum Env {


### PR DESCRIPTION
This modifies the format of the 'issuedBy' that we are expecting from the TxMA self serve. The supplied config was resulting in an output that has the final string in an array unexpectedly. 